### PR TITLE
Fix Pinecone client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ pip install torch transformers
 - `ELEVENLABS_API_KEY`
 - `ELEVENLABS_VOICE_ID`
 - `PINECONE_API_KEY`
-- `PINECONE_ENV`
+- `PINECONE_HOST` *(controller URL)*
 - `PINECONE_INDEX`
-- `PINECONE_HOST`
 - `PINECONE_EMBEDDING_MODEL`
 
 4. Place Shaka Senghor's writings (txt/markdown) inside `data/corpus/`.
@@ -80,7 +79,6 @@ python3 scripts/train.py --data data/processed/corpus.jsonl --out model/
 
 ```bash
 PINECONE_API_KEY=your_key
-PINECONE_ENV=your_env
 PINECONE_INDEX=shaka
 PINECONE_HOST=https://shakata-xvax471.svc.apw5-4e34-81fa.pinecone.io
 PINECONE_EMBEDDING_MODEL=text-embedding-3-large
@@ -107,6 +105,6 @@ The React UI is served from `client/` and is accessible in the browser at `http:
 
 
 The repository's `.gitignore` excludes `.env` so your credentials remain local.
-- Pinecone configuration is handled in `server/utils/pinecone.js` via environment variables `PINECONE_API_KEY`, `PINECONE_ENV`, and `PINECONE_INDEX`.
+- Pinecone configuration is handled in `server/utils/pinecone.js` via environment variables `PINECONE_API_KEY`, `PINECONE_HOST`, and `PINECONE_INDEX`.
 
 This MVP is intended for private use on a local machine.

--- a/server/utils/pinecone.js
+++ b/server/utils/pinecone.js
@@ -6,10 +6,12 @@ const logger = require('./logger');
 // Initialise the Pinecone client using the API key and environment from the
 // environment variables.  The `Pinecone` constructor is available in the
 // latest versions of the SDK and replaces the older `PineconeClient` class.
+// The latest Pinecone Node SDK expects only an apiKey and optional
+// controllerHostUrl when instantiating the client.  Passing legacy
+// `environment` or `host` properties results in a PineconeArgumentError.
 const pinecone = new Pinecone({
   apiKey: process.env.PINECONE_API_KEY || '',
-  environment: process.env.PINECONE_ENV || 'us-east1-gcp',
-  host: process.env.PINECONE_HOST
+  controllerHostUrl: process.env.PINECONE_HOST
 });
 
 const indexName = process.env.PINECONE_INDEX || 'shaka';


### PR DESCRIPTION
## Summary
- update Pinecone client initialization to use `controllerHostUrl`
- update README environment variable instructions

## Testing
- `npm test`