### PR TITLE
Update README for Llama 3.2 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,21 @@ npm install
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install torch transformers
+pip install torch transformers datasets
 ```
 
-3. Set environment variables for ElevenLabs and Pinecone:
+3. Install an inference server to run Llama locally for query. The
+   [Ollama](https://ollama.ai) CLI provides a convenient API:
+
+```bash
+curl -fsSL https://ollama.ai/install.sh | sh
+ollama pull llama3.2:1b  # base model with 1B parameters
+ollama serve &      # serves at http://localhost:11434
+```
+
+The `LLAMA_ENDPOINT` variable defaults to this address.
+
+4. Set environment variables for ElevenLabs and Pinecone:
 
 - `ELEVENLABS_API_KEY`
 - `ELEVENLABS_VOICE_ID`
@@ -56,8 +67,8 @@ pip install torch transformers
 - `PINECONE_INDEX`
 - `PINECONE_EMBEDDING_MODEL`
 
-4. Place Shaka Senghor's writings (txt/markdown) inside `data/corpus/`.
-5. Run the ingestion script to prepare the corpus:
+5. Place Shaka Senghor's writings (txt/markdown) inside `data/corpus/`.
+6. Run the ingestion script to prepare the corpus:
 
 
 ```bash
@@ -65,18 +76,18 @@ node scripts/ingest.js
 ```
 
 
-5. (Optional) Fine‑tune the Llama model using the provided training script:
+7. (Optional) Fine‑tune the Llama model using the provided training script:
 
 
 ```bash
 python3 scripts/train.py --data data/processed/corpus.jsonl \
-    --out model/ --model path-or-name-of-base-llama
+    --out model/ --model llama3.2:1b
 ```
 
 
 
 
-6. Set environment variables for Pinecone and ElevenLabs in a `.env` file or your shell:
+8. Set environment variables for Pinecone and ElevenLabs in a `.env` file or your shell:
 
 ```bash
 PINECONE_API_KEY=your_key
@@ -84,12 +95,12 @@ PINECONE_INDEX=shaka
 PINECONE_HOST=https://shakata-xvax471.svc.apw5-4e34-81fa.pinecone.io
 PINECONE_EMBEDDING_MODEL=text-embedding-3-large
 LLAMA_ENDPOINT=http://localhost:11434/v1/chat/completions
-LLAMA_MODEL=shaka
+LLAMA_MODEL=llama3.2:1b  # change to your fine-tuned model name when ready
 ELEVENLABS_API_KEY=your_elevenlabs_key
 ELEVENLABS_VOICE_ID=your_voice_id
 ```
 
-7. Start the API server:er:
+9. Start the API server:
 
 ```bash
 npm start
@@ -100,7 +111,7 @@ The React UI is served from `client/` and is accessible in the browser at `http:
 
 ## Notes
 
-- `server/services/llm.js` queries a local Llama model. Configure the `LLAMA_ENDPOINT` and `LLAMA_MODEL` environment variables to point at your running inference server.
+- `server/services/llm.js` queries a local Llama model. Configure the `LLAMA_ENDPOINT` and `LLAMA_MODEL` environment variables to point at your running inference server.  `LLAMA_MODEL` defaults to `llama3.2:1b` but can be set to your fine-tuned model.
 - `server/services/tts.js` calls the ElevenLabs API and requires `ELEVENLABS_API_KEY` and `ELEVENLABS_VOICE_ID` environment variables.
 
 


### PR DESCRIPTION
## Summary
- recommend installing Ollama with `llama3.2:1b`
- use the same base model for training examples
- update example `.env` to start with `llama3.2:1b`
- clarify that `LLAMA_MODEL` defaults to this base model

## Testing
- `npm test`