### PR TITLE
Load env vars from file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+PINECONE_API_KEY=your_pinecone_key
+PINECONE_ENV=us-west-2
+PINECONE_INDEX=shaka
+PINECONE_HOST=https://shakata-xvax471.svc.apw5-4e34-81fa.pinecone.io
+PINECONE_EMBEDDING_MODEL=text-embedding-3-large
+ELEVENLABS_API_KEY=your_elevenlabs_key
+ELEVENLABS_VOICE_ID=your_voice_id
+LLAMA_ENDPOINT=http://localhost:11434/v1/chat/completions
+LLAMA_MODEL=llama3.2:1b

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ python3 scripts/train.py --data data/processed/corpus.jsonl \
 
 
 
-8. Set environment variables for Pinecone and ElevenLabs in a `.env` file or your shell:
+8. Create a `.env` file (a sample `.env.example` is provided) with your Pinecone
+   and ElevenLabs credentials. The server loads this file from the repository
+   root at startup, even if you launch the app from within the `server/` folder:
 
 ```bash
 PINECONE_API_KEY=your_key

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "winston": "^3.9.0",
     "axios": "^1.6.8",
     "@pinecone-database/pinecone": "^6.0.0",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5"
   },
   "type": "commonjs"
 }

--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,16 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const dotenv = require('dotenv');
 const logger = require('./utils/logger');
+
+// Load environment variables from the repo root `.env` file, even if the server
+// is started from within the `server/` directory.
+dotenv.config({ path: path.join(__dirname, '../.env') });
+
+if (!process.env.PINECONE_API_KEY) {
+  logger.warn('PINECONE_API_KEY not set. Check your .env file.');
+}
 
 const chatRouter = require('./routes/chat');
 const audioRouter = require('./routes/audio');

--- a/server/utils/pinecone.js
+++ b/server/utils/pinecone.js
@@ -9,8 +9,13 @@ const logger = require('./logger');
 // The latest Pinecone Node SDK expects only an apiKey and optional
 // controllerHostUrl when instantiating the client.  Passing legacy
 // `environment` or `host` properties results in a PineconeArgumentError.
+if (!process.env.PINECONE_API_KEY) {
+  logger.error('PINECONE_API_KEY is not defined');
+  throw new Error('Missing Pinecone configuration');
+}
+
 const pinecone = new Pinecone({
-  apiKey: process.env.PINECONE_API_KEY || '',
+  apiKey: process.env.PINECONE_API_KEY,
   controllerHostUrl: process.env.PINECONE_HOST
 });
 


### PR DESCRIPTION
## Summary
- load variables from `.env`
- document `.env` loading in README
- provide `.env.example`
- add dotenv dependency
- ensure the server loads `.env` from repo root, warn if missing
- validate Pinecone config early

## Testing
- `npm test`
