### PR TITLE
Improve device selection and add tests

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -26,6 +26,24 @@ from transformers import (
 )
 
 
+def select_device(local_rank: int) -> str:
+    """Return a torch device string for ``local_rank``.
+
+    Raises ``ValueError`` if ``local_rank`` points to a GPU that does not
+    exist in the current environment.
+    """
+
+    if local_rank >= 0 and torch.cuda.is_available():
+        count = torch.cuda.device_count()
+        if local_rank >= count:
+            raise ValueError(
+                f"Invalid device index {local_rank}; only {count} GPU(s) available."
+            )
+        return f"cuda:{local_rank}"
+
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
 def main(
     data_path: str,
     model_dir: str,
@@ -41,10 +59,7 @@ def main(
     default) the script behaves as before and simply picks ``cuda`` if
     available.
     """
-    if local_rank >= 0 and torch.cuda.is_available():
-        device = f"cuda:{local_rank}"
-    else:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = select_device(local_rank)
     print(
         f"Training with {data_path}; base model {base_model}; output to {model_dir}"
     )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+import importlib
+
+import pytest
+
+# Ensure scripts package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide minimal stubs for optional dependencies
+if "torch" not in sys.modules:
+    torch_stub = types.SimpleNamespace()
+    cuda_stub = types.SimpleNamespace(
+        is_available=lambda: False, device_count=lambda: 0
+    )
+    torch_stub.cuda = cuda_stub
+    sys.modules["torch"] = torch_stub
+
+if "datasets" not in sys.modules:
+    datasets_stub = types.ModuleType("datasets")
+    datasets_stub.load_dataset = lambda *_, **__: None
+    sys.modules["datasets"] = datasets_stub
+
+if "transformers" not in sys.modules:
+    transformers_stub = types.ModuleType("transformers")
+    for attr in [
+        "AutoTokenizer",
+        "AutoModelForCausalLM",
+        "DataCollatorForLanguageModeling",
+        "Trainer",
+        "TrainingArguments",
+    ]:
+        setattr(transformers_stub, attr, object)
+    sys.modules["transformers"] = transformers_stub
+
+train = importlib.import_module("scripts.train")
+select_device = train.select_device
+
+
+def test_select_device_valid_gpu(monkeypatch):
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+    monkeypatch.setattr("torch.cuda.device_count", lambda: 2)
+    assert select_device(1) == "cuda:1"
+
+
+def test_select_device_invalid_rank(monkeypatch):
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+    monkeypatch.setattr("torch.cuda.device_count", lambda: 1)
+    with pytest.raises(ValueError):
+        select_device(1)
+
+
+def test_select_device_cpu(monkeypatch):
+    monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+    assert select_device(-1) == "cpu"


### PR DESCRIPTION
## Summary
- add `select_device` helper to validate `local_rank`
- integrate helper into training script
- provide unit tests for device selection logic with dependency stubs

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*