### PR TITLE
Add low-bit model option

### DIFF
--- a/tests/test_bits.py
+++ b/tests/test_bits.py
@@ -1,0 +1,69 @@
+import importlib
+import os
+import sys
+import types
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class DummyArgs:
+    def __init__(self, *a, **k):
+        DummyArgs.kwargs = k
+
+
+class DummyTrainer:
+    def __init__(self, *a, **k):
+        pass
+
+    def train(self):
+        pass
+
+    def save_model(self, *a, **k):
+        pass
+
+
+def setup_modules(called):
+    fake_torch = types.ModuleType("torch")
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False, device_count=lambda: 0)
+
+    ds_stub = types.SimpleNamespace(map=lambda *a, **k: [])
+    fake_ds = types.ModuleType("datasets")
+    fake_ds.load_dataset = lambda *a, **k: {"train": ds_stub}
+
+    def fake_from_pretrained(*a, **k):
+        called.update(k)
+        return types.SimpleNamespace(to=lambda *_: None)
+
+    fake_tf = types.ModuleType("transformers")
+    fake_tf.AutoTokenizer = types.SimpleNamespace(
+        from_pretrained=lambda *a, **k: types.SimpleNamespace(pad_token=None, eos_token="</s>")
+    )
+    fake_tf.AutoModelForCausalLM = types.SimpleNamespace(from_pretrained=fake_from_pretrained)
+    fake_tf.DataCollatorForLanguageModeling = lambda tokenizer=None, mlm=False: object()
+    fake_tf.Trainer = DummyTrainer
+    fake_tf.TrainingArguments = DummyArgs
+
+    return {"torch": fake_torch, "datasets": fake_ds, "transformers": fake_tf}
+
+
+def test_load_in_8bit(tmp_path):
+    called = {}
+    modules = setup_modules(called)
+    with mock.patch.dict(sys.modules, modules):
+        train = importlib.import_module("scripts.train")
+        importlib.reload(train)
+        train.main("data", str(tmp_path), "model", 1, 1, -1, False, 8)
+        assert called.get("load_in_8bit") is True
+    sys.modules.pop("scripts.train", None)
+
+
+def test_load_in_4bit(tmp_path):
+    called = {}
+    modules = setup_modules(called)
+    with mock.patch.dict(sys.modules, modules):
+        train = importlib.import_module("scripts.train")
+        importlib.reload(train)
+        train.main("data", str(tmp_path), "model", 1, 1, -1, False, 4)
+        assert called.get("load_in_4bit") is True
+    sys.modules.pop("scripts.train", None)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -34,23 +34,24 @@ if "transformers" not in sys.modules:
         setattr(transformers_stub, attr, object)
     sys.modules["transformers"] = transformers_stub
 
-train = importlib.import_module("scripts.train")
-select_device = train.select_device
 
 
 def test_select_device_valid_gpu(monkeypatch):
     monkeypatch.setattr("torch.cuda.is_available", lambda: True)
     monkeypatch.setattr("torch.cuda.device_count", lambda: 2)
-    assert select_device(1) == "cuda:1"
+    train = importlib.reload(importlib.import_module("scripts.train"))
+    assert train.select_device(1) == "cuda:1"
 
 
 def test_select_device_invalid_rank(monkeypatch):
     monkeypatch.setattr("torch.cuda.is_available", lambda: True)
     monkeypatch.setattr("torch.cuda.device_count", lambda: 1)
+    train = importlib.reload(importlib.import_module("scripts.train"))
     with pytest.raises(ValueError):
-        select_device(1)
+        train.select_device(1)
 
 
 def test_select_device_cpu(monkeypatch):
     monkeypatch.setattr("torch.cuda.is_available", lambda: False)
-    assert select_device(-1) == "cpu"
+    train = importlib.reload(importlib.import_module("scripts.train"))
+    assert train.select_device(-1) == "cpu"


### PR DESCRIPTION
## Summary
- support loading models in 8-bit or 4-bit precision
- test low-bit options and reload training module in device tests

## Testing
- `pytest -q`