### PR TITLE
Docs: Update training command in README for OOM errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,11 @@ python3 scripts/train.py --data data/processed/corpus.jsonl \
     --out model/ --model ./models/llama3.2-1b
 ```
 
-For multi-GPU machines, launch via `torchrun` so each process is assigned a
-different GPU:
-
-```bash
-CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node=2 \
-  scripts/train.py --data data/processed/corpus.jsonl \
-  --out model/ --model ./models/llama3.2-1b
+# For multi-GPU machines, launch via torchrun.
+# If you encounter CUDA OutOfMemory errors, try the following command which enables
+# 4-bit quantization, gradient checkpointing, and a batch size of 1
+# to significantly reduce memory usage:
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True CUDA_VISIBLE_DEVICES=0,1   torchrun --standalone --nproc_per_node=1 scripts/train.py   --data data/processed/corpus.jsonl --out model/   --model meta-llama/Llama-3.2-1B   --batch-size 1 --gradient-checkpointing --bits 4
 ```
 
 The training script will automatically detect whether CUDA is available and, if


### PR DESCRIPTION
The previous multi-GPU training example in README.md did not include common parameters for handling CUDA OutOfMemory issues when training large models like Llama-3.2-1B.

This change updates the example command to include:
- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` to help with memory fragmentation.
- `--batch-size 1` for minimal memory per batch.
- `--gradient-checkpointing` to trade compute for memory.
- `--bits 4` for 4-bit model quantization, significantly reducing model memory footprint.

A note has also been added to explain why these parameters are useful for memory-constrained environments. The model name in the example has been updated to `meta-llama/Llama-3.2-1B` and `nproc_per_node` to 1 to match the context of the originating issue.