### PR TITLE
feat: Add gradient accumulation to training script

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -78,6 +78,7 @@ def main(
     local_rank: int,
     gradient_checkpointing: bool = False,
     bits: int = 16,
+    gradient_accumulation_steps: int = 1, # New parameter
 ):
     """Run the fine-tuning loop.
 
@@ -153,6 +154,7 @@ def main(
         fp16=fp16,
         local_rank=local_rank,
         gradient_checkpointing=gradient_checkpointing,
+        gradient_accumulation_steps=gradient_accumulation_steps, # New argument
     )
 
     trainer = Trainer(model=model, args=args, train_dataset=tokenized, data_collator=collator)
@@ -187,6 +189,12 @@ if __name__ == "__main__":
         default=int(os.environ.get("LOCAL_RANK", -1)),
         help="Provided by torchrun for distributed training",
     )
+    parser.add_argument(
+        "--gradient-accumulation-steps",
+        type=int,
+        default=1,
+        help="Number of steps to accumulate gradients before performing an optimizer step",
+    )
     args = parser.parse_args()
 
     Path(args.out).mkdir(parents=True, exist_ok=True)
@@ -199,4 +207,5 @@ if __name__ == "__main__":
         args.local_rank,
         args.gradient_checkpointing,
         args.bits,
+        args.gradient_accumulation_steps, # Pass new argument
     )


### PR DESCRIPTION
This commit introduces gradient accumulation to the `scripts/train.py` script to help you mitigate CUDA Out-of-Memory (OOM) errors during training.

A new command-line argument `--gradient-accumulation-steps` (integer, defaulting to 1) has been added. This value is passed to the `gradient_accumulation_steps` parameter in `transformers.TrainingArguments`.

To use this feature, you can set the `--gradient-accumulation-steps` to a value greater than 1. For example:

PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node=1 scripts/train.py --data data/processed/corpus.jsonl --out model/ --model EleutherAI/pythia-14m --batch-size 1 --gradient-checkpointing --bits 16 --gradient-accumulation-steps 4

This will accumulate gradients over 4 batches before performing an optimizer step, effectively reducing memory usage at the cost of longer training time per epoch (as updates are less frequent). You can experiment with different values (e.g., 2, 4, 8, 16) to find what works best for your setup.

If OOM errors persist even with gradient accumulation, you might consider using 4-bit or 8-bit quantization, which is already supported by the script via the `--bits 4` or `--bits 8` arguments. This significantly reduces memory footprint but may have a minor impact on model performance. For example:

PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc_per_node=1 scripts/train.py --data data/processed/corpus.jsonl --out model/ --model EleutherAI/pythia-14m --batch-size 1 --gradient-checkpointing --bits 8 --gradient-accumulation-steps 4