### PR TITLE
docs: Add missing training dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ npm install
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install torch transformers datasets
+pip install torch transformers datasets peft bitsandbytes accelerate
 ```
+   - `peft`: For Parameter-Efficient Fine-Tuning.
+   - `bitsandbytes`: Required if you plan to use 4-bit or 8-bit model quantization (via the `--bits` flag in `train.py`).
+   - `accelerate`: Helps manage and run your models efficiently, especially for distributed setups or when using features like `device_map="auto"`.
 
 3. Install an inference server to run Llama locally for query. The
    [Ollama](https://ollama.ai) CLI provides a convenient API:


### PR DESCRIPTION
The training script `scripts/train.py` uses the `peft` library for Parameter-Efficient Fine-Tuning. This was not listed in the setup instructions in the README.md.

This commit updates the `pip install` instructions to include:
- `peft`: For LoRA and other fine-tuning techniques.
- `bitsandbytes`: Required for model quantization (4-bit/8-bit) which is an option in the training script.
- `accelerate`: Often used with Hugging Face Transformers for efficient model handling and distributed training.

These additions will help you set up your environment correctly for running the training script.