### PR TITLE
Fix: Add max_seq_length to control tokenization length

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -79,6 +79,7 @@ def main(
     gradient_checkpointing: bool = False,
     bits: int = 16,
     gradient_accumulation_steps: int = 1, # New parameter
+    max_seq_length: int,
 ):
     """Run the fine-tuning loop.
 
@@ -142,7 +143,7 @@ def main(
     # should already be on the correct device from the previous .to(device) call or device_map.
 
     def tokenize(batch):
-        return tokenizer(batch["text"], truncation=True, padding="max_length")
+        return tokenizer(batch["text"], truncation=True, padding="max_length", max_length=max_seq_length)
 
     tokenized = dataset.map(tokenize, batched=True, remove_columns=["text"])
 
@@ -202,6 +203,7 @@ if __name__ == "__main__":
         default=1,
         help="Number of steps to accumulate gradients before performing an optimizer step",
     )
+    parser.add_argument("--max_seq_length", type=int, default=512, help="Maximum sequence length for tokenization.")
     args = parser.parse_args()
 
     Path(args.out).mkdir(parents=True, exist_ok=True)
@@ -215,4 +217,5 @@ if __name__ == "__main__":
         args.gradient_checkpointing,
         args.bits,
         args.gradient_accumulation_steps, # Pass new argument
+        args.max_seq_length,
     )


### PR DESCRIPTION
Introduces a `--max_seq_length` command-line argument to the `scripts/train.py` script. This allows you to specify the maximum sequence length for tokenization, defaulting to 512.

Previously, the tokenizer would pad to the model's maximum supported length by default when `padding="max_length"` was used without an explicit `max_length`. This could lead to CUDA OutOfMemory errors when training models with large context windows, as the memory required for attention masks and activations scales with sequence length.

By setting a configurable `max_seq_length`, you can now manage memory usage more effectively and prevent OOM errors. The `tokenize` function has been updated to use this new parameter.