### PR TITLE
Fix: Correct SyntaxError in train.py function signature

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -79,7 +79,7 @@ def main(
     gradient_checkpointing: bool = False,
     bits: int = 16,
     gradient_accumulation_steps: int = 1, # New parameter
-    max_seq_length: int,
+    max_seq_length: int = 512, # Added default value here
 ):
     """Run the fine-tuning loop.
 


### PR DESCRIPTION
The `main` function in `scripts/train.py` had a `SyntaxError` because the `max_seq_length` parameter, which did not have a default value, was defined after parameters that did have default values.

This commit fixes the error by adding a default value of `512` to the `max_seq_length` parameter, consistent with its default value in the script's `argparse` setup.

I was unable to run tests due to unrelated environment issues (disk space).