### PR TITLE
Fix ImportError for BitsAndBytesConfig

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+transformers
+bitsandbytes
+torch
+datasets

--- a/tests/test_bits.py
+++ b/tests/test_bits.py
@@ -40,6 +40,7 @@ def setup_modules(called):
         from_pretrained=lambda *a, **k: types.SimpleNamespace(pad_token=None, eos_token="</s>")
     )
     fake_tf.AutoModelForCausalLM = types.SimpleNamespace(from_pretrained=fake_from_pretrained)
+    fake_tf.BitsAndBytesConfig = types.SimpleNamespace()
     fake_tf.DataCollatorForLanguageModeling = lambda tokenizer=None, mlm=False: object()
     fake_tf.Trainer = DummyTrainer
     fake_tf.TrainingArguments = DummyArgs

--- a/tests/test_device_map.py
+++ b/tests/test_device_map.py
@@ -36,6 +36,7 @@ def test_auto_device_map_multi_gpu(tmp_path):
         from_pretrained=lambda *a, **k: types.SimpleNamespace(pad_token=None, eos_token="</s>")
     )
     fake_tf.AutoModelForCausalLM = types.SimpleNamespace(from_pretrained=fake_from_pretrained)
+    fake_tf.BitsAndBytesConfig = types.SimpleNamespace()
     fake_tf.DataCollatorForLanguageModeling = lambda tokenizer=None, mlm=False: object()
     fake_tf.Trainer = DummyTrainer
     fake_tf.TrainingArguments = DummyArgs

--- a/tests/test_gradient_ckpt.py
+++ b/tests/test_gradient_ckpt.py
@@ -36,6 +36,7 @@ def test_gradient_checkpointing_flag(tmp_path):
     fake_tf.AutoModelForCausalLM = types.SimpleNamespace(
         from_pretrained=lambda *a, **k: types.SimpleNamespace(to=lambda *_: None)
     )
+    fake_tf.BitsAndBytesConfig = types.SimpleNamespace()
     fake_tf.DataCollatorForLanguageModeling = lambda tokenizer=None, mlm=False: object()
     fake_tf.TrainingArguments = DummyArgs
     fake_tf.Trainer = DummyTrainer


### PR DESCRIPTION
The tests were failing due to an ImportError for BitsAndBytesConfig. This was likely caused by the 'transformers' and 'bitsandbytes' libraries not being installed in the test environment.

This commit addresses the issue by:
1. Creating a `requirements.txt` file with the necessary dependencies.
2. Mocking `BitsAndBytesConfig` in the test files to avoid import errors during testing.

Note: I was unable to run tests due to an insufficient disk space issue in the execution environment.