### PR TITLE
Fix tokenizer padding and tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -p no:warnings
+testpaths = tests

--- a/scripts/chunk_text.py
+++ b/scripts/chunk_text.py
@@ -2,8 +2,10 @@ import os
 from pathlib import Path
 from transformers import AutoTokenizer
 
-# Initialize tokenizer
+# Initialize tokenizer and ensure a pad token is defined
 tokenizer = AutoTokenizer.from_pretrained("gpt2")
+if tokenizer.pad_token is None:
+    tokenizer.pad_token = tokenizer.eos_token
 
 # Define configurable variables
 max_tokens = 512
@@ -33,6 +35,8 @@ def clean_text(text):
 
 def chunk_text(text, tokenizer, max_tokens, stride):
     """Chunks the text using the tokenizer."""
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
     tokens = tokenizer(
         text,
         return_overflowing_tokens=True,

--- a/tests/test_chunk_text.py
+++ b/tests/test_chunk_text.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+from unittest import mock
+import types
+
+class DummyTokenizer:
+    def __init__(self):
+        self.pad_token = None
+        self.eos_token = "</s>"
+
+    def __call__(self, text, return_overflowing_tokens=True, truncation=True,
+                 max_length=512, stride=0, padding="longest", return_tensors="pt"):
+        if self.pad_token is None:
+            raise ValueError("pad_token is None")
+        return {"input_ids": [[0, 1]]}
+
+    def batch_decode(self, ids, skip_special_tokens=True):
+        return ["decoded"]
+
+def test_chunk_text_sets_pad_token():
+    dummy = DummyTokenizer()
+    tf_stub = types.ModuleType("transformers")
+    tf_stub.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: dummy)
+    with mock.patch.dict(sys.modules, {"transformers": tf_stub}):
+        if "scripts.chunk_text" in sys.modules:
+            del sys.modules["scripts.chunk_text"]
+        ct = importlib.import_module("scripts.chunk_text")
+    assert dummy.pad_token == dummy.eos_token
+    chunks = ct.chunk_text("text", dummy, 10, 2)
+    assert chunks == ["decoded"]
+

--- a/tests/test_model_path.py
+++ b/tests/test_model_path.py
@@ -9,27 +9,31 @@ import unittest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Minimal stubs for optional dependencies to avoid heavy imports
-if "torch" not in sys.modules:
-    torch_stub = types.SimpleNamespace()
-    torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False, device_count=lambda: 0)
-    sys.modules["torch"] = torch_stub
+torch_stub = types.SimpleNamespace()
+torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False, device_count=lambda: 0)
+sys.modules["torch"] = torch_stub
 
-if "datasets" not in sys.modules:
-    datasets_stub = types.ModuleType("datasets")
-    datasets_stub.load_dataset = lambda *_, **__: None
-    sys.modules["datasets"] = datasets_stub
+datasets_stub = types.ModuleType("datasets")
+datasets_stub.load_dataset = lambda *_, **__: None
+sys.modules["datasets"] = datasets_stub
 
-if "transformers" not in sys.modules:
-    transformers_stub = types.ModuleType("transformers")
-    for attr in [
-        "AutoTokenizer",
-        "AutoModelForCausalLM",
-        "DataCollatorForLanguageModeling",
-        "Trainer",
-        "TrainingArguments",
-    ]:
-        setattr(transformers_stub, attr, object)
-    sys.modules["transformers"] = transformers_stub
+transformers_stub = types.ModuleType("transformers")
+for attr in [
+    "AutoTokenizer",
+    "AutoModelForCausalLM",
+    "BitsAndBytesConfig",
+    "DataCollatorForLanguageModeling",
+    "Trainer",
+    "TrainingArguments",
+]:
+    setattr(transformers_stub, attr, object)
+sys.modules["transformers"] = transformers_stub
+
+peft_stub = types.ModuleType("peft")
+peft_stub.get_peft_model = lambda *a, **k: object()
+peft_stub.LoraConfig = object
+peft_stub.TaskType = types.SimpleNamespace(CAUSAL_LM="CAUSAL_LM")
+sys.modules["peft"] = peft_stub
 
 train = importlib.import_module("scripts.train")
 resolve_model_path = train.resolve_model_path

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,8 +1,12 @@
 import importlib
+import os
 import sys
 import types
 import unittest
 from unittest import mock
+
+# Ensure scripts package is importable when tests are run from the tests folder
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Create a minimal fake torch module for testing
 fake_torch = types.ModuleType('torch')
@@ -15,14 +19,21 @@ fake_datasets.load_dataset = lambda *a, **k: {'train': []}
 fake_transformers = types.ModuleType('transformers')
 fake_transformers.AutoTokenizer = object
 fake_transformers.AutoModelForCausalLM = object
+fake_transformers.BitsAndBytesConfig = object
 fake_transformers.DataCollatorForLanguageModeling = object
 fake_transformers.Trainer = object
 fake_transformers.TrainingArguments = object
+
+fake_peft = types.ModuleType('peft')
+fake_peft.get_peft_model = lambda *a, **k: object()
+fake_peft.LoraConfig = object
+fake_peft.TaskType = types.SimpleNamespace(CAUSAL_LM='CAUSAL_LM')
 
 with mock.patch.dict(sys.modules, {
     'torch': fake_torch,
     'datasets': fake_datasets,
     'transformers': fake_transformers,
+    'peft': fake_peft,
 }):
     train = importlib.import_module('scripts.train')
 


### PR DESCRIPTION
## Summary
- set GPT2 pad token when none defined
- ensure chunk_text also sets pad_token on supplied tokenizer
- add pytest configuration
- add unit test for chunk_text
- make stubs consistent in tests

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb08587e48325b0b8bcc4bb1f1e99