### PR TITLE
Add axolotl cli check

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Execute the `run_finetuning.sh` script to start the Axolotl fine-tuning process.
 bash scripts/run_finetuning.sh
 ```
 
+The script verifies that the `axolotl` command is available and exits with an informative message if it isn't. Ensure the CLI is installed and on your `PATH`.
+
 This will:
 - Use the `config.yaml` for settings.
 - Read the dataset from `data/processed/formatted_dataset.txt`.

--- a/scripts/run_finetuning.sh
+++ b/scripts/run_finetuning.sh
@@ -24,6 +24,11 @@ echo "Output will be saved to the directory specified in config.yaml (./output b
 
 # Command to run Axolotl
 # Ensure Axolotl is installed and accessible in your environment.
+if ! command -v axolotl >/dev/null 2>&1; then
+    echo "Error: Axolotl CLI not found. Please install it and ensure it is in your PATH."
+    exit 1
+fi
+
 axolotl train ./config.yaml
 
 # Check exit status of Axolotl

--- a/tests/test_run_finetuning.py
+++ b/tests/test_run_finetuning.py
@@ -1,0 +1,27 @@
+import subprocess
+from pathlib import Path
+
+def test_run_finetuning_requires_axolotl(tmp_path):
+    # create minimal dataset and config
+    data_dir = tmp_path / "data" / "processed"
+    data_dir.mkdir(parents=True)
+    dataset = data_dir / "formatted_dataset.txt"
+    dataset.write_text("dummy\n")
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        f"dataset:\n  path: {dataset}\ntraining:\n  output_dir: {tmp_path / 'out'}\n"
+    )
+
+    script_dst = tmp_path / "run_finetuning.sh"
+    script_src = Path(__file__).resolve().parent.parent / "scripts" / "run_finetuning.sh"
+    script_dst.write_text(script_src.read_text())
+    script_dst.chmod(0o755)
+
+    result = subprocess.run([
+        "bash",
+        str(script_dst)
+    ], cwd=tmp_path, capture_output=True, text=True)
+
+    assert result.returncode != 0
+    assert "Axolotl CLI not found" in result.stdout


### PR DESCRIPTION
## Summary
- exit run_finetuning.sh early when `axolotl` command is missing
- document the new check in the README
- add regression test for the shell script

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*
- `npx eslint server/app.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683fb80f32408325b6d9fd9eeb5d8225