### PR TITLE
Update config for new Axolotl dataset syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This will generate `data/processed/formatted_dataset.txt`.
 
 The default fine-tuning parameters are set in `config.yaml`. You can modify this file to change:
 - `base_model`: If you want to use a different LLaMA model.
-- `dataset.path`: If your formatted dataset is named or located differently.
+- `datasets[0].path`: If your formatted dataset is named or located differently.
 - `training.*`: Parameters like `num_train_epochs`, `learning_rate`, `per_device_train_batch_size`, etc.
 - `bf16`: Set to `false` if your GPU does not support bfloat16.
 
@@ -207,7 +207,7 @@ The script verifies that the `axolotl` command is available and exits with an in
 
 This will:
 - Use the `config.yaml` for settings.
-- Read the dataset from `data/processed/formatted_dataset.txt`.
+- Read the dataset from `data/processed/formatted_dataset.txt` (as referenced by `datasets[0].path`).
 - Save model checkpoints and the final model to the `./output/` directory (or as specified in `config.yaml`).
 
 The process can take a significant amount of time depending on your dataset size, hardware, and training epochs.

--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,9 @@ model_type: LlamaForCausalLM
 load_in_4bit: true
 adapter: qlora
 
-dataset:
-  path: ./data/processed/formatted_dataset.txt
-  type: text
+datasets:
+  - path: ./data/processed/formatted_dataset.txt
+    type: text
 
 training:
   output_dir: ./output

--- a/tests/test_run_finetuning.py
+++ b/tests/test_run_finetuning.py
@@ -10,7 +10,7 @@ def test_run_finetuning_requires_axolotl(tmp_path):
 
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        f"dataset:\n  path: {dataset}\ntraining:\n  output_dir: {tmp_path / 'out'}\n"
+        f"datasets:\n  - path: {dataset}\n    type: text\ntraining:\n  output_dir: {tmp_path / 'out'}\n"
     )
 
     script_dst = tmp_path / "run_finetuning.sh"


### PR DESCRIPTION
## Summary
- adjust config.yaml to use `datasets` key
- document new syntax in README
- update `test_run_finetuning` for updated config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fdf270aec8325bcb5621df2e0ad26