### PR TITLE
Fix finetuning test path

### DIFF
--- a/tests/test_run_finetuning.py
+++ b/tests/test_run_finetuning.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+import shutil
 
 
 def test_run_finetuning_requires_trl(tmp_path):
@@ -13,10 +14,14 @@ def test_run_finetuning_requires_trl(tmp_path):
     script_dst.write_text(script_src.read_text())
     script_dst.chmod(0o755)
 
+    train_src = Path(__file__).resolve().parent.parent / "scripts" / "train.py"
+    train_dst = tmp_path / "train.py"
+    shutil.copy(train_src, train_dst)
+
     result = subprocess.run([
         "bash",
         str(script_dst)
     ], cwd=tmp_path, capture_output=True, text=True)
 
     assert result.returncode != 0
-    assert "TRL or PEFT not installed" in result.stdout
+    assert "TRL or PEFT not installed" in result.stdout or "TRL or PEFT not installed" in result.stderr


### PR DESCRIPTION
## Summary
- copy `train.py` when running run_finetuning test
- allow assertion to look at stdout or stderr

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428ae6615483259ecf8e62f1f36d97