### PR TITLE
Fix gradient checkpointing with DDP

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -180,6 +180,7 @@ def main(
         local_rank=local_rank,
         gradient_checkpointing=gradient_checkpointing,
         gradient_accumulation_steps=gradient_accumulation_steps, # New argument
+        ddp_find_unused_parameters=False,
     )
 
     trainer = Trainer(model=model, args=args, train_dataset=tokenized, data_collator=collator)

--- a/tests/test_gradient_ckpt.py
+++ b/tests/test_gradient_ckpt.py
@@ -62,6 +62,7 @@ def test_gradient_checkpointing_flag(tmp_path):
         importlib.reload(train)
         train.main('data', str(tmp_path), 'model', 1, 1, -1, True)
         assert DummyArgs.kwargs['gradient_checkpointing'] is True
+        assert DummyArgs.kwargs['ddp_find_unused_parameters'] is False
 
 
 def test_enable_input_grads_called(tmp_path):


### PR DESCRIPTION
## Summary
- avoid DDP unused parameter detection while gradient checkpointing
- ensure tests check that `ddp_find_unused_parameters` is disabled

## Testing
- `ruff check scripts/train.py`
- `ruff check tests/test_gradient_ckpt.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843a2f57d54832596c5cb26d31e7f09