### PR TITLE
Fix finetuning dataset path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ data/corpus/*.txt
 
 # Ignore the processed dataset file
 data/processed/formatted_dataset.txt
+data/processed/corpus.jsonl
 
 # Ignore model outputs and checkpoints
 output/

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ This project provides scripts and configuration to fine-tune a LLaMA model (e.g.
 - `data/`:
     - `corpus/`: Place your raw author text files (`.txt`) here. You can create subdirectories.
         - `.gitkeep`: Placeholder, safe to remove if you add your own data.
-    - `processed/`: Output directory for the formatted dataset.
-        - `formatted_dataset.txt`: The chunked and formatted text data for training.
+    - `processed/`: Output directory for the processed dataset.
+        - `corpus.jsonl`: JSONL file with one object per text chunk.
         - `.gitkeep`: Placeholder.
 - `scripts/`:
     - `chunk_text.py`: Python script to process raw text files into a formatted dataset.
@@ -180,7 +180,7 @@ Run the `chunk_text.py` script to process your raw text files into the required 
 python scripts/chunk_text.py
 ```
 
-This will generate `data/processed/formatted_dataset.txt`.
+This will generate `data/processed/corpus.jsonl`.
 
 ### 3. Configure Fine-Tuning (Optional)
 
@@ -205,7 +205,7 @@ bash scripts/run_finetuning.sh
 The script checks that the required Python packages are installed and then launches `train.py` with sensible defaults.
 
 This will:
-- Read the dataset from `data/processed/formatted_dataset.txt`.
+- Read the dataset from `data/processed/corpus.jsonl`.
 
 The process can take a significant amount of time depending on your dataset size, hardware, and training epochs.
 
@@ -232,7 +232,7 @@ The script will load the model and enter an interactive mode where you can type 
 A helper script, `scripts/modal_train.py`, submits the fine-tuning job to [Modal](https://modal.com/). After installing the `modal` package and running `python3 -m modal setup`, launch training remotely:
 
 ```bash
-modal run scripts/modal_train.py --data data/processed/formatted_dataset.txt \
+modal run scripts/modal_train.py --data data/processed/corpus.jsonl \
   --out output --model Llama-3.2-1B --epochs 3 --batch-size 4 --bits 4 \
   --gradient-checkpointing
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ load_in_4bit: true
 adapter: qlora
 
 datasets:
-  - path: ./data/processed/formatted_dataset.txt
+  - path: ./data/processed/corpus.jsonl
     type: text
 
 training:

--- a/scripts/run_finetuning.sh
+++ b/scripts/run_finetuning.sh
@@ -2,7 +2,7 @@
 
 # Run fine-tuning using Hugging Face TRL with PEFT (LoRA).
 
-DATASET="./data/processed/formatted_dataset.txt"
+DATASET="./data/processed/corpus.jsonl"
 OUT_DIR="./output"
 MODEL="Llama-3.2-1B"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Check for required dataset
 if [ ! -f "$DATASET" ]; then
   echo "Error: Dataset file $DATASET not found."
-  echo "Please run scripts/chunk_text.py first."
+  echo "Please run: node scripts/ingest.js"
   exit 1
 fi
 

--- a/tests/test_run_finetuning.py
+++ b/tests/test_run_finetuning.py
@@ -6,7 +6,7 @@ import shutil
 def test_run_finetuning_requires_trl(tmp_path):
     data_dir = tmp_path / "data" / "processed"
     data_dir.mkdir(parents=True)
-    dataset = data_dir / "formatted_dataset.txt"
+    dataset = data_dir / "corpus.jsonl"
     dataset.write_text("dummy\n")
 
     script_dst = tmp_path / "run_finetuning.sh"


### PR DESCRIPTION
## Summary
- use `corpus.jsonl` as the training dataset
- update config and documentation for new dataset name
- adjust tests and `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a3d10790832589f3ad7788aa3cdb